### PR TITLE
Update bloggify link

### DIFF
--- a/views/footer.jade
+++ b/views/footer.jade
@@ -5,7 +5,7 @@ div.footer.text-center &copy; #{new Date().getFullYear()}  • #{config.site.tit
   = " "
   | from Romania. Powered by
   = " "
-  a(href="http://bloggify.github.com") Bloggify
+  a(href="https://bloggify.org/") Bloggify
   = "."
   br
   | Sponsored by


### PR DESCRIPTION
It was pointing to https://bloggify.github.com earlier.